### PR TITLE
fix fibonacci.py

### DIFF
--- a/Algorithms/Dynamic-Programming/fibonacci.py
+++ b/Algorithms/Dynamic-Programming/fibonacci.py
@@ -1,29 +1,40 @@
 import unittest
 
-'''
-Fibonacci
+memo = {}
 
-Write a function `fib(n)` that takes in a number as an argument. The function should
-return the n-th number of the Fibonacci sequence
 
-The 1st and 2nd number of the fibonacci sequence is 1. To generate the next number,
-sum the previous two 
-'''
-#tc = 0(2^n) | sc = 0(n)
+def fib(n):
+    if n < 0:
+        raise Exception(f"Invalid input: {n}")
 
-def fib(n, memo = {}):
-  if n in memo:
-    return memo[n]
-  if n <= 2:
-    return 1
-  memo[n] = fib(n - 1) + fib(n -1)
-  return memo[n]
+    if n == 0:
+        return 0
+
+    if n == 1:
+        return 1
+
+    if n in memo:
+        return memo[n]
+
+    current_fib_number = fib(n - 1) + fib(n - 2)
+    memo[n] = current_fib_number
+
+    return current_fib_number
+
 
 class Test(unittest.TestCase):
-  def test_fib(self):
-    self.assertEqual(fib(9), 128)
-    self.assertEqual(fib(50), 281474976710656)
-    self.assertEqual(fib(2), 1)
-    
+    def test_fib(self):
+        with self.assertRaises(Exception):
+            fib(-1)
+        self.assertEqual(fib(9), 34)
+        self.assertEqual(fib(50), 12586269025)
+        self.assertEqual(fib(10), 55)
+        self.assertEqual(fib(0), 0)
+        self.assertEqual(fib(1), 1)
+        self.assertEqual(fib(6), 8)
+        self.assertEqual(fib(37), 24157817)
+        self.assertEqual(fib(2), 1)
+
+
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
fixed the Fibonacci program from the original forked repo.

It had some problems:
- the computation of the Fibonacci numbers was wrong because the asserts were wrong, be careful with that. 
You can check Fibonacci numbers (here)[https://www.omnicalculator.com/math/fibonacci] and (here)[https://www.calculatorsoup.com/calculators/discretemathematics/fibonacci-calculator.php]

- there was an error on line 19: it should be "fib(n - 1) + fib(n -2)", NO "fib(n - 1) + fib(n -1)"

- there was an error on line 17 and 18. That code block is wrong:
  if n <= 2:
    return 1
because the fibonacci of 0 is 0, no 1. 

- it would be nice to check for edge cases like negative numbers, included in the new solution

- you are assigning a mutable empty object directly to a default argument to a function. In Python this technique should be done differently because assigning directly the empty set as a default parameter, can make your function reuse that parameter (the same set) for all the function invocations! In this exercise this is theoretically correct because we want to use the "memo" dict as a cache (and reuse it in all calls), but in general, is a better practice to assign as a default parameter the value "None" and then inside the function check if the parameter is "None" and in that case assign to it the empty dictionary ("{}").

I provide a link with a great explanation of the problem and some solutions: https://realpython.com/fibonacci-sequence-python/#memoizing-the-recursive-algorithm
and a blog talking about how to use default mutable parameters in Python: https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/#:~:text=In%20Python%2C%20when%20passing%20a,or%20even%20a%20class%20instance.